### PR TITLE
Fix WARP INFO always showing "LOADING"

### DIFF
--- a/DEFAULT--.conf
+++ b/DEFAULT--.conf
@@ -458,7 +458,7 @@ handlers:
       end
       if warpdrive then
        local decodeW = decodeJSON(warpdrive.getWidgetData())
-       warpData.Info = decodeW.buttonMsg or "LOADING"
+       warpData.Info = decodeW.statusText or "LOADING"
        warpData.Cells = decodeW.cellCount or 0
        warpData.Destination = decodeW.destination or "LOADING"
        warpData.Distance = decodeW.distance or "LOADING"


### PR DESCRIPTION
Currently WARP INFO in INFO window always shows "LOADING". This fix will use statusText from widget data as value. Alternatively we could use buttonText, but I believe statusText is more informative than just "UNABLE TO WARP"