### PR TITLE
Fix deprecated getDataId() usages

### DIFF
--- a/DEFAULT--.conf
+++ b/DEFAULT--.conf
@@ -3798,14 +3798,14 @@ handlers:
       if (P.WS.w_parenting.value == "Default" and ALT == false) or (P.WS.w_parenting.value == "ALT" and ALT == true)then
        parentingPanelId = system.createWidgetPanel("Docking")
        parentingWidgetId = system.createWidget(parentingPanelId,"parenting")
-       system.addDataToWidget(unit.getDataId(),parentingWidgetId)
+       system.addDataToWidget(unit.getWidgetDataId(),parentingWidgetId)
       end
 
       -- COMBAT STRESS
       if (P.WS.w_cstress.value == "Default" and ALT == false) or (P.WS.w_cstress.value == "ALT" and ALT == true)then
        coreCombatStressPanelId = system.createWidgetPanel("Core combat stress")
        coreCombatStressgWidgetId = system.createWidget(coreCombatStressPanelId,"core_stress")
-       system.addDataToWidget(core.getDataId(),coreCombatStressgWidgetId)
+       system.addDataToWidget(core.getWidgetDataId(),coreCombatStressgWidgetId)
       end
 
       -- SHIELD


### PR DESCRIPTION
Changes `getDataId()` to `getWidgetDataId()`