### PR TITLE
"FTL" in platform HUD

### DIFF
--- a/DEFAULT--.conf
+++ b/DEFAULT--.conf
@@ -1453,8 +1453,10 @@ handlers:
 
      --animated text
      local gndH = Gnd.height > 0 and floor(round(Gnd.height)).."m" or " N/A"
+     local speed = format("%.0f",xyzSpeedKPH)
+     if xyzSpeedKPH > 50000 then speed = "FTL" end
      local SVG_text_anim = [[<g text-anchor="end" font-family="]]..widget_font..[[" alignment-baseline="bottom" stroke-width="0" fill="]]..wAC..[[">
-      <text x="170" y="25" font-size="21">]]..format("%.0f",xyzSpeedKPH)..[[</text>
+      <text x="170" y="25" font-size="21">]]..speed..[[</text>
       <text x="195" y="17.5" font-size="10">km/h</text>
      </g>
      <g font-size="7" text-anchor="start" font-family="]]..widget_font..[[" alignment-baseline="bottom" stroke-width="0" fill="]]..wAC..[[">


### PR DESCRIPTION
When speed indicator in HUD shows "FTL", do the same in Platform HUD.

![image](https://github.com/TheGreatSardini/Default--/assets/236859/3e55b5d6-25b5-4090-816f-657b5a228404)
